### PR TITLE
Use processor conventions from #4616

### DIFF
--- a/plugins/processors/all/all.go
+++ b/plugins/processors/all/all.go
@@ -6,6 +6,6 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/processors/override"
 	_ "github.com/influxdata/telegraf/plugins/processors/printer"
 	_ "github.com/influxdata/telegraf/plugins/processors/regex"
-	_ "github.com/influxdata/telegraf/plugins/processors/topk"
 	_ "github.com/influxdata/telegraf/plugins/processors/strings"
+	_ "github.com/influxdata/telegraf/plugins/processors/topk"
 )

--- a/plugins/processors/strings/README.md
+++ b/plugins/processors/strings/README.md
@@ -6,10 +6,10 @@ Implemented functions are:
 - lowercase
 - uppercase
 - trim
+- trim_left
+- trim_right
 - trim_prefix
 - trim_suffix
-- trim_right
-- trim_left
 
 Please note that in this implementation these are processed in the order that they appear above.
 
@@ -56,12 +56,28 @@ The `trim`, `trim_left`, and `trim_right` functions take an optional parameter: 
 The `trim_prefix` and `trim_suffix` functions remote the given `prefix` or `suffix`
 respectively from the string.
 
+### Example
+**Config**
+```toml
+[[processors.strings]]
+  [[processors.strings.lowercase]]
+    field = "uri-stem"
 
-### Example Input:
+  [[processors.strings.trim_prefix]]
+    field = "uri_stem"
+    prefix = "/api/"
+
+  [[processors.strings.uppercase]]
+    field = "cs-host"
+    dest = "cs-host_normalised"
+```
+
+**Input**
 ```
 iis_log,method=get,uri_stem=/API/HealthCheck cs-host="MIXEDCASE_host",referrer="-",ident="-",http_version=1.1,agent="UserAgent",resp_bytes=270i 1519652321000000000
 ```
-### Example Output:
+
+**Output**
 ```
 iis_log,method=get,uri_stem=healthcheck cs-host="MIXEDCASE_host",cs-host_normalised="MIXEDCASE_HOST",referrer="-",ident="-",http_version=1.1,agent="UserAgent",resp_bytes=270i 1519652321000000000
 ```

--- a/plugins/processors/strings/README.md
+++ b/plugins/processors/strings/README.md
@@ -1,42 +1,61 @@
 # Strings Processor Plugin
 
-The `strings` plugin maps certain go string functions onto tag and field values. If `result_key` parameter is present, it can produce new tags and fields from existing ones.
+The `strings` plugin maps certain go string functions onto measurement, tag, and field values.  Values can be modified in place or stored in another key.
 
-Implemented functions are: Lowercase, Uppercase, Trim, TrimPrefix, TrimSuffix, TrimRight, TrimLeft
+Implemented functions are:
+- lowercase
+- uppercase
+- trim
+- trim_prefix
+- trim_suffix
+- trim_right
+- trim_left
 
 Please note that in this implementation these are processed in the order that they appear above.
 
-Specify the `tag` or `field` that you want processed in each section and optionally a `result_key` if you want the result stored in a new tag or field. You can specify lots of transformations on data with a single strings processor. Certain functions require an `argument` field to specify how they should process their throughput.
-
-Functions that require an `argument` are: Trim, TrimPrefix, TrimSuffix, TrimRight, TrimLeft
+Specify the `measurement`, `tag` or `field` that you want processed in each section and optionally a `dest` if you want the result stored in a new tag or field. You can specify lots of transformations on data with a single strings processor.
 
 ### Configuration:
 
 ```toml
 [[processors.strings]]
-  namepass = ["uri_stem"]
+  # [[processors.strings.uppercase]]
+  #   tag = "method"
 
-  # Tag and field conversions defined in a separate sub-tables
-  [[processors.strings.lowercase]]
-    ## Tag to change
-    tag = "uri_stem"
+  # [[processors.strings.lowercase]]
+  #   field = "uri_stem"
+  #   dest = "uri_stem_normalised"
 
-  [[processors.strings.lowercase]]
-    ## Multiple tags or fields may be defined
-    tag = "method"
+  ## Convert a tag value to lowercase
+  # [[processors.strings.trim]]
+  #   field = "message"
 
-  [[processors.strings.uppercase]]
-    key = "cs-host"
-    result_key = "cs-host_normalised"
+  # [[processors.strings.trim_left]]
+  #   field = "message"
+  #   cutset = "\t"
 
-  [[processors.strings.trimprefix]]
-    tag = "uri_stem"
-    argument = "/api/"
+  # [[processors.strings.trim_right]]
+  #   field = "message"
+  #   cutset = "\r\n"
+
+  # [[processors.strings.trim_prefix]]
+  #   field = "my_value"
+  #   prefix = "my_"
+
+  # [[processors.strings.trim_suffix]]
+  #   field = "read_count"
+  #   suffix = "_count"
 ```
 
-### Tags:
+#### Trim, TrimLeft, TrimRight
 
-No tags are applied by this processor.
+The `trim`, `trim_left`, and `trim_right` functions take an optional parameter: `cutset`.  This value is a string containing the characters to remove from the value.
+
+#### TrimPrefix, TrimSuffix
+
+The `trim_prefix` and `trim_suffix` functions remote the given `prefix` or `suffix`
+respectively from the string.
+
 
 ### Example Input:
 ```

--- a/plugins/processors/strings/strings_test.go
+++ b/plugins/processors/strings/strings_test.go
@@ -1,22 +1,25 @@
 package strings
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newM1() telegraf.Metric {
 	m1, _ := metric.New("IIS_log",
 		map[string]string{
 			"verb":           "GET",
-            "s-computername": "MIXEDCASE_hostname",
+			"s-computername": "MIXEDCASE_hostname",
 		},
 		map[string]interface{}{
-            "request": "/mixed/CASE/paTH/?from=-1D&to=now",
+			"request":    "/mixed/CASE/paTH/?from=-1D&to=now",
+			"whitespace": "  whitespace\t",
 		},
 		time.Now(),
 	)
@@ -28,11 +31,11 @@ func newM2() telegraf.Metric {
 		map[string]string{
 			"verb":           "GET",
 			"resp_code":      "200",
-            "s-computername": "MIXEDCASE_hostname",
+			"s-computername": "MIXEDCASE_hostname",
 		},
 		map[string]interface{}{
-            "request":       "/mixed/CASE/paTH/?from=-1D&to=now",
-            "cs-host":       "AAAbbb",
+			"request":       "/mixed/CASE/paTH/?from=-1D&to=now",
+			"cs-host":       "AAAbbb",
 			"ignore_number": int64(200),
 			"ignore_bool":   true,
 		},
@@ -43,275 +46,353 @@ func newM2() telegraf.Metric {
 
 func TestFieldConversions(t *testing.T) {
 	tests := []struct {
-		message        string
-		lowercase      converter
-        uppercase      converter
-        trim           converter
-        trimleft       converter
-        trimright      converter
-        trimprefix     converter
-        trimsuffix     converter
-		expectedFields map[string]interface{}
+		name   string
+		plugin *Strings
+		check  func(t *testing.T, actual telegraf.Metric)
 	}{
 		{
-			message: "Should change existing field to lowercase",
-			lowercase: converter{
-				Field:         "request",
+			name: "Should change existing field to lowercase",
+			plugin: &Strings{
+				Lowercase: []converter{
+					converter{
+						Field: "request",
+					},
+				},
 			},
-			expectedFields: map[string]interface{}{
-                "request": "/mixed/case/path/?from=-1d&to=now",
-			},
-		},
-		{
-			message: "Should change existing field to uppercase",
-			uppercase: converter{
-				Field:         "request",
-			},
-			expectedFields: map[string]interface{}{
-                "request": "/MIXED/CASE/PATH/?FROM=-1D&TO=NOW",
+			check: func(t *testing.T, actual telegraf.Metric) {
+				fv, ok := actual.GetField("request")
+				require.True(t, ok)
+				require.Equal(t, "/mixed/case/path/?from=-1d&to=now", fv)
 			},
 		},
 		{
-			message: "Should add new lowercase field",
-			lowercase: converter{
-				Field:         "request",
-				ResultKey:   "lowercase_request",
+			name: "Should change existing field to uppercase",
+			plugin: &Strings{
+				Uppercase: []converter{
+					converter{
+						Field: "request",
+					},
+				},
 			},
-			expectedFields: map[string]interface{}{
-                "request": "/mixed/CASE/paTH/?from=-1D&to=now",
-                "lowercase_request": "/mixed/case/path/?from=-1d&to=now",
-			},
-		},
-		{
-			message: "Should trim from both sides",
-			trim: converter{
-				Field:         "request",
-                Argument:      "/w",
-			},
-			expectedFields: map[string]interface{}{
-                "request": "mixed/CASE/paTH/?from=-1D&to=no",
+			check: func(t *testing.T, actual telegraf.Metric) {
+				fv, ok := actual.GetField("request")
+				require.True(t, ok)
+				require.Equal(t, "/MIXED/CASE/PATH/?FROM=-1D&TO=NOW", fv)
 			},
 		},
 		{
-			message: "Should trim from both sides and make lowercase",
-			trim: converter{
-				Field:         "request",
-                Argument:      "/w",
+			name: "Should add new lowercase field",
+			plugin: &Strings{
+				Lowercase: []converter{
+					converter{
+						Field: "request",
+						Dest:  "lowercase_request",
+					},
+				},
 			},
-            lowercase: converter{
-                Field:         "request",
-            },
-			expectedFields: map[string]interface{}{
-                "request": "mixed/case/path/?from=-1d&to=no",
-			},
-		},
-		{
-			message: "Should trim from left side",
-			trimleft: converter{
-				Field:         "request",
-                Argument:      "/w",
-			},
-			expectedFields: map[string]interface{}{
-                "request": "mixed/CASE/paTH/?from=-1D&to=now",
+			check: func(t *testing.T, actual telegraf.Metric) {
+				fv, ok := actual.GetField("request")
+				require.True(t, ok)
+				require.Equal(t, "/mixed/CASE/paTH/?from=-1D&to=now", fv)
+
+				fv, ok = actual.GetField("lowercase_request")
+				require.True(t, ok)
+				require.Equal(t, "/mixed/case/path/?from=-1d&to=now", fv)
 			},
 		},
 		{
-			message: "Should trim from right side",
-			trimright: converter{
-				Field:         "request",
-                Argument:      "/w",
+			name: "Should trim from both sides",
+			plugin: &Strings{
+				Trim: []converter{
+					converter{
+						Field:  "request",
+						Cutset: "/w",
+					},
+				},
 			},
-			expectedFields: map[string]interface{}{
-                "request": "/mixed/CASE/paTH/?from=-1D&to=no",
-			},
-		},
-		{
-			message: "Should trim prefix '/mixed'",
-			trimprefix: converter{
-				Field:         "request",
-                Argument:      "/mixed",
-			},
-			expectedFields: map[string]interface{}{
-                "request": "/CASE/paTH/?from=-1D&to=now",
+			check: func(t *testing.T, actual telegraf.Metric) {
+				fv, ok := actual.GetField("request")
+				require.True(t, ok)
+				require.Equal(t, "mixed/CASE/paTH/?from=-1D&to=no", fv)
 			},
 		},
 		{
-			message: "Should trim suffix '-1D&to=now'",
-			trimprefix: converter{
-				Field:         "request",
-                Argument:      "-1D&to=now",
+			name: "Should trim from both sides and make lowercase",
+			plugin: &Strings{
+				Trim: []converter{
+					converter{
+						Field:  "request",
+						Cutset: "/w",
+					},
+				},
+				Lowercase: []converter{
+					converter{
+						Field: "request",
+					},
+				},
 			},
-			expectedFields: map[string]interface{}{
-                "request": "/mixed/CASE/paTH/?from=-1D&to=now",
+			check: func(t *testing.T, actual telegraf.Metric) {
+				fv, ok := actual.GetField("request")
+				require.True(t, ok)
+				require.Equal(t, "mixed/case/path/?from=-1d&to=no", fv)
+			},
+		},
+		{
+			name: "Should trim from left side",
+			plugin: &Strings{
+				TrimLeft: []converter{
+					converter{
+						Field:  "request",
+						Cutset: "/w",
+					},
+				},
+			},
+			check: func(t *testing.T, actual telegraf.Metric) {
+				fv, ok := actual.GetField("request")
+				require.True(t, ok)
+				require.Equal(t, "mixed/CASE/paTH/?from=-1D&to=now", fv)
+			},
+		},
+		{
+			name: "Should trim from right side",
+			plugin: &Strings{
+				TrimRight: []converter{
+					converter{
+						Field:  "request",
+						Cutset: "/w",
+					},
+				},
+			},
+			check: func(t *testing.T, actual telegraf.Metric) {
+				fv, ok := actual.GetField("request")
+				require.True(t, ok)
+				require.Equal(t, "/mixed/CASE/paTH/?from=-1D&to=no", fv)
+			},
+		},
+		{
+			name: "Should trim prefix '/mixed'",
+			plugin: &Strings{
+				TrimPrefix: []converter{
+					converter{
+						Field:  "request",
+						Prefix: "/mixed",
+					},
+				},
+			},
+			check: func(t *testing.T, actual telegraf.Metric) {
+				fv, ok := actual.GetField("request")
+				require.True(t, ok)
+				require.Equal(t, "/CASE/paTH/?from=-1D&to=now", fv)
+			},
+		},
+		{
+			name: "Should trim suffix '-1D&to=now'",
+			plugin: &Strings{
+				TrimSuffix: []converter{
+					converter{
+						Field:  "request",
+						Suffix: "-1D&to=now",
+					},
+				},
+			},
+			check: func(t *testing.T, actual telegraf.Metric) {
+				fv, ok := actual.GetField("request")
+				require.True(t, ok)
+				require.Equal(t, "/mixed/CASE/paTH/?from=", fv)
+			},
+		},
+		{
+			name: "Trim without cutset removes whitespace",
+			plugin: &Strings{
+				Trim: []converter{
+					converter{
+						Field: "whitespace",
+					},
+				},
+			},
+			check: func(t *testing.T, actual telegraf.Metric) {
+				fv, ok := actual.GetField("whitespace")
+				require.True(t, ok)
+				require.Equal(t, "whitespace", fv)
+			},
+		},
+		{
+			name: "Trim left without cutset removes whitespace",
+			plugin: &Strings{
+				TrimLeft: []converter{
+					converter{
+						Field: "whitespace",
+					},
+				},
+			},
+			check: func(t *testing.T, actual telegraf.Metric) {
+				fv, ok := actual.GetField("whitespace")
+				require.True(t, ok)
+				require.Equal(t, "whitespace\t", fv)
+			},
+		},
+		{
+			name: "Trim right without cutset removes whitespace",
+			plugin: &Strings{
+				TrimRight: []converter{
+					converter{
+						Field: "whitespace",
+					},
+				},
+			},
+			check: func(t *testing.T, actual telegraf.Metric) {
+				fv, ok := actual.GetField("whitespace")
+				require.True(t, ok)
+				require.Equal(t, "  whitespace", fv)
+			},
+		},
+		{
+			name: "No change if field missing",
+			plugin: &Strings{
+				Lowercase: []converter{
+					converter{
+						Field:  "xyzzy",
+						Suffix: "-1D&to=now",
+					},
+				},
+			},
+			check: func(t *testing.T, actual telegraf.Metric) {
+				fv, ok := actual.GetField("request")
+				require.True(t, ok)
+				require.Equal(t, "/mixed/CASE/paTH/?from=-1D&to=now", fv)
 			},
 		},
 	}
-
-	for _, test := range tests {
-		strings := &Strings{}
-		strings.Lowercase = []converter{
-			test.lowercase,
-		}
-        strings.Uppercase = []converter{
-            test.uppercase,
-        }
-        strings.Trim = []converter{
-            test.trim,
-        }
-        strings.TrimLeft = []converter{
-            test.trimleft,
-        }
-        strings.TrimRight = []converter{
-            test.trimright,
-        }
-        strings.TrimPrefix = []converter{
-            test.trimprefix,
-        }
-        strings.TrimSuffix = []converter{
-            test.trimsuffix,
-        }
-
-		processed := strings.Apply(newM1())
-
-		expectedTags := map[string]string{
-			"verb":           "GET",
-            "s-computername": "MIXEDCASE_hostname",
-		}
-
-		assert.Equal(t, test.expectedFields, processed[0].Fields(), test.message)
-		assert.Equal(t, expectedTags, processed[0].Tags(), "Should not change tags")
-		assert.Equal(t, "IIS_log", processed[0].Name(), "Should not change name")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := tt.plugin.Apply(newM1())
+			require.Len(t, metrics, 1)
+			tt.check(t, metrics[0])
+		})
 	}
 }
 
 func TestTagConversions(t *testing.T) {
 	tests := []struct {
-		message      string
-		lowercase    converter
-        uppercase    converter
-		expectedTags map[string]string
+		name   string
+		plugin *Strings
+		check  func(t *testing.T, actual telegraf.Metric)
 	}{
 		{
-			message: "Should change existing tag to lowercase",
-			lowercase: converter{
-				Tag:         "s-computername",
+			name: "Should change existing tag to lowercase",
+			plugin: &Strings{
+				Lowercase: []converter{
+					converter{
+						Tag: "s-computername",
+					},
+				},
 			},
-			expectedTags: map[string]string{
-				"verb":    "GET",
-                "s-computername": "mixedcase_hostname",
-			},
-		},
-		{
-			message: "Should add new lowercase tag",
-			lowercase: converter{
-				Tag:         "s-computername",
-				ResultKey:   "s-computername_lowercase",
-			},
-			expectedTags: map[string]string{
-				"verb":       "GET",
-                "s-computername": "MIXEDCASE_hostname",
-                "s-computername_lowercase": "mixedcase_hostname",
+			check: func(t *testing.T, actual telegraf.Metric) {
+				tv, ok := actual.GetTag("verb")
+				require.True(t, ok)
+				require.Equal(t, "GET", tv)
+
+				tv, ok = actual.GetTag("s-computername")
+				require.True(t, ok)
+				require.Equal(t, "mixedcase_hostname", tv)
 			},
 		},
 		{
-			message: "Should add new uppercase tag",
-			uppercase: converter{
-				Tag:         "s-computername",
-				ResultKey:   "s-computername_uppercase",
+			name: "Should add new lowercase tag",
+			plugin: &Strings{
+				Lowercase: []converter{
+					converter{
+						Tag:  "s-computername",
+						Dest: "s-computername_lowercase",
+					},
+				},
 			},
-			expectedTags: map[string]string{
-				"verb":       "GET",
-                "s-computername": "MIXEDCASE_hostname",
-                "s-computername_uppercase": "MIXEDCASE_HOSTNAME",
+			check: func(t *testing.T, actual telegraf.Metric) {
+				tv, ok := actual.GetTag("verb")
+				require.True(t, ok)
+				require.Equal(t, "GET", tv)
+
+				tv, ok = actual.GetTag("s-computername")
+				require.True(t, ok)
+				require.Equal(t, "MIXEDCASE_hostname", tv)
+
+				tv, ok = actual.GetTag("s-computername_lowercase")
+				require.True(t, ok)
+				require.Equal(t, "mixedcase_hostname", tv)
+			},
+		},
+		{
+			name: "Should add new uppercase tag",
+			plugin: &Strings{
+				Uppercase: []converter{
+					converter{
+						Tag:  "s-computername",
+						Dest: "s-computername_uppercase",
+					},
+				},
+			},
+			check: func(t *testing.T, actual telegraf.Metric) {
+				tv, ok := actual.GetTag("verb")
+				require.True(t, ok)
+				require.Equal(t, "GET", tv)
+
+				tv, ok = actual.GetTag("s-computername")
+				require.True(t, ok)
+				require.Equal(t, "MIXEDCASE_hostname", tv)
+
+				tv, ok = actual.GetTag("s-computername_uppercase")
+				require.True(t, ok)
+				require.Equal(t, "MIXEDCASE_HOSTNAME", tv)
 			},
 		},
 	}
 
-	for _, test := range tests {
-		strings := &Strings{}
-		strings.Lowercase = []converter{
-			test.lowercase,
-		}
-		strings.Uppercase = []converter{
-			test.uppercase,
-		}
-
-		processed := strings.Apply(newM1())
-
-		expectedFields := map[string]interface{}{
-            "request": "/mixed/CASE/paTH/?from=-1D&to=now",
-		}
-
-		assert.Equal(t, expectedFields, processed[0].Fields(), test.message, "Should not change fields")
-		assert.Equal(t, test.expectedTags, processed[0].Tags(), test.message)
-		assert.Equal(t, "IIS_log", processed[0].Name(), "Should not change name")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := tt.plugin.Apply(newM1())
+			require.Len(t, metrics, 1)
+			tt.check(t, metrics[0])
+		})
 	}
 }
 
 func TestMultipleConversions(t *testing.T) {
-	strings := &Strings{}
-	strings.Lowercase = []converter{
-		{
-			Tag:         "s-computername",
+	fmt.Println(2)
+	plugin := &Strings{
+		Lowercase: []converter{
+			converter{
+				Tag: "s-computername",
+			},
+			converter{
+				Field: "request",
+			},
+			converter{
+				Field: "cs-host",
+				Dest:  "cs-host_lowercase",
+			},
 		},
-		{
-			Field:       "request",
-		},
-		{
-			Field:       "cs-host",
-			ResultKey:   "cs-host_lowercase",
+		Uppercase: []converter{
+			converter{
+				Tag: "verb",
+			},
 		},
 	}
-    strings.Uppercase = []converter{
-        {
-            Tag:        "verb",
-        },
-    }
 
-	processed := strings.Apply(newM2())
+	processed := plugin.Apply(newM2())
 
 	expectedFields := map[string]interface{}{
-        "request":           "/mixed/case/path/?from=-1d&to=now",
+		"request":           "/mixed/case/path/?from=-1d&to=now",
 		"ignore_number":     int64(200),
 		"ignore_bool":       true,
-        "cs-host":           "AAAbbb",
-        "cs-host_lowercase": "aaabbb",
+		"cs-host":           "AAAbbb",
+		"cs-host_lowercase": "aaabbb",
 	}
 	expectedTags := map[string]string{
 		"verb":           "GET",
-        "resp_code":      "200",
-        "s-computername": "mixedcase_hostname",
+		"resp_code":      "200",
+		"s-computername": "mixedcase_hostname",
 	}
 
 	assert.Equal(t, expectedFields, processed[0].Fields())
 	assert.Equal(t, expectedTags, processed[0].Tags())
-}
-
-func TestNoKey(t *testing.T) {
-	tests := []struct {
-		message        string
-		converter      converter
-		expectedFields map[string]interface{}
-	}{
-		{
-			message: "Should not change anything if there is no field with given key",
-			converter: converter{
-				Field:         "not_exists",
-			},
-			expectedFields: map[string]interface{}{
-                "request": "/mixed/CASE/paTH/?from=-1D&to=now",
-			},
-		},
-	}
-
-	for _, test := range tests {
-		strings := &Strings{}
-		strings.Lowercase = []converter{
-			test.converter,
-		}
-
-		processed := strings.Apply(newM1())
-
-		assert.Equal(t, test.expectedFields, processed[0].Fields(), test.message)
-	}
 }


### PR DESCRIPTION
I made a few changes to the strings processor, based on my ideas in 
https://github.com/influxdata/telegraf/issues/4616.  This PR is basically just some renamed fields and formatting issues.

I also wanted to lay some groundwork to ease adding #4599 as an additional function. 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
